### PR TITLE
fix(telnet): narrow 'data' event payload to Buffer

### DIFF
--- a/src/connection/telnet.ts
+++ b/src/connection/telnet.ts
@@ -211,8 +211,12 @@ export async function connect(
       startKeepAlive();
 
       telnetClient.on('data', (data) => {
-        // Check for and handle telnet commands
-        const processedData = processTelnetCommands(data);
+        // Check for and handle telnet commands.
+        // The socket is left in raw byte mode (no setEncoding() call), so
+        // `data` is always a Buffer at runtime; the union with `string`
+        // only exists in the @types/node signature.
+        const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+        const processedData = processTelnetCommands(buf);
         
         if (processedData.length > 0) {
           const text = processedData.toString();


### PR DESCRIPTION
  `npm run build` fails on current `@types/node` (v25):

```bash
$ npm run build

> mcp-telnet@0.6.0 build
> tsc && shx chmod +x dist/*.js && node scripts/update-version.js

src/connection/telnet.ts:215:53 - error TS2345: Argument of type 'string | NonSharedBuffer' is not assignable to parameter of type 'Buffer<ArrayBufferLike>'.
  Type 'string' is not assignable to type 'Buffer<ArrayBufferLike>'.

215         const processedData = processTelnetCommands(data);
                                                        ~~~~


Found 1 error in src/connection/telnet.ts:215
```
`net.Socket`'s `'data'` event is typed as `string | NonSharedBuffer`, but `processTelnetCommands` only accepts `Buffer`. The socket is never put into encoding mode, so at runtime the payload is always a `Buffer` — purely a typing issue.

Narrow with `Buffer.isBuffer()` at the call site.