### PR TITLE
Don't block startup on restoring an unreachable connection

### DIFF
--- a/src/connection/telnet.ts
+++ b/src/connection/telnet.ts
@@ -548,18 +548,27 @@ export async function reconnectToActiveConnections(): Promise<void> {
       passphrase: conn.passphrase
     };
     
-    try {
-      await connect(conn.host, conn.port, conn.name, tlsOptions);
-    } catch (error) {
-      const errorMessage = formatError(error);
-      log(`Failed to reconnect: ${errorMessage}`, 'error');
-      
-      // Mark as inactive
+    // Mark the connection inactive on failure so a host that has gone away
+    // isn't retried on every subsequent startup. `connect` reports failure by
+    // resolving rather than throwing, so both paths have to be handled.
+    const markInactive = () => {
       const index = savedConnections.findIndex((c: SavedConnection) => c.name === conn.name);
       if (index !== -1) {
         savedConnections[index].isActive = false;
         saveSavedConnections();
       }
+    };
+
+    try {
+      const result = await connect(conn.host, conn.port, conn.name, tlsOptions);
+      if (!result.success) {
+        log(`Failed to reconnect: ${result.message}`, 'error');
+        markInactive();
+      }
+    } catch (error) {
+      const errorMessage = formatError(error);
+      log(`Failed to reconnect: ${errorMessage}`, 'error');
+      markInactive();
     }
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,17 +60,24 @@ Example:
 
   // Start interactive CLI
   startInteractiveCLI();
-  
-  // Only try to reconnect if identity is set
-  if (isLLMIdentified()) {
-    // Connect to any active connections
-    await reconnectToActiveConnections();
-  }
-  
-  // Start the MCP server
+
+  // Start the MCP server before touching the network. Restoring a previous
+  // telnet connection can stall for as long as the socket timeout when the
+  // host is gone, and blocking here means the client never sees a response
+  // to `initialize` and reports the server as failed to start.
   const transport = new StdioServerTransport();
   await server.connect(transport);
   log("MCP-Telnet server running on stdio");
-  
+
+  // Only try to reconnect if identity is set. This runs in the background so
+  // an unreachable host degrades to "not connected" instead of taking the
+  // whole server down with it.
+  if (isLLMIdentified()) {
+    reconnectToActiveConnections().catch(error => {
+      const message = error instanceof Error ? error.message : String(error);
+      log(`Background reconnect failed: ${message}`, 'error');
+    });
+  }
+
   return server;
 }


### PR DESCRIPTION
Fixes #16.

## What was happening

`startServer()` awaited `reconnectToActiveConnections()` before calling `server.connect(transport)`. If the saved connection's host was gone, the TCP connect sat there until the 30s socket timeout, and the stdio transport wasn't listening yet — so the client's `initialize` request went unanswered and the server was reported as failed to start.

It also repeated on every launch, because the dead connection never got un-flagged. `reconnectToActiveConnections()` only cleared `isActive` from its `catch`, but `connect()` reports failure by resolving with `success: false` instead of throwing. The equivalent cleanup inside `connect()`'s error handler is guarded on `connectionState.name`, which is still `""` on a fresh process since `handleConnection()` never ran.

## Changes

- `src/server.ts` — connect the transport first, then start the reconnect in the background (with a `.catch()` so it can't become an unhandled rejection). A host that's down now just leaves you disconnected instead of taking the server with it.
- `src/connection/telnet.ts` — treat a resolved `success: false` as a failure, same as a throw.
- Version bumped to 0.6.1 across `package.json`, `package-lock.json`, and `manifest.json`.

## Testing

Ran the built server against a fixture `HOME` and drove a real MCP handshake over stdio:

| Scenario | Before | After |
| --- | --- | --- |
| Black-holed host (`192.0.2.1:2300`) | no `initialize` response within 15s | responds in 82ms |
| Refused host (`127.0.0.1:1`) | `isActive` stayed `true` | `initialize` and `tools/list` both answered, process alive, `isActive` cleared |
| Reachable host (local listener) | — | still reconnects at startup, stays active |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
